### PR TITLE
Fix #97 colour selector

### DIFF
--- a/src/assets/css/custom.scss
+++ b/src/assets/css/custom.scss
@@ -13,7 +13,6 @@ $constrainer-width: map-get($container-max-widths, 'xl')+160px;
     border-top: 0;
     border-bottom: 0;
     margin: auto;
-    overflow: hidden;
     width: $constrainer-width;
   }
 }

--- a/src/assets/css/custom.scss
+++ b/src/assets/css/custom.scss
@@ -3,10 +3,11 @@
 
 $constrainer-width: map-get($container-max-widths, 'xl')+160px;
 
-.constrainer {
+#root {
   background-color: #fff;
-  overflow: hidden;
+}
 
+.constrainer {
   @media (min-width: $constrainer-width+1px) {
     border: 1px solid rgba($black, .125);
     border-top: 0;

--- a/src/assets/css/custom.scss
+++ b/src/assets/css/custom.scss
@@ -14,6 +14,11 @@ $constrainer-width: map-get($container-max-widths, 'xl')+160px;
     border-bottom: 0;
     margin: auto;
     width: $constrainer-width;
+    &::before, &::after {
+      content: "";
+      display: table;
+      clear: both;
+    }
   }
 }
 

--- a/src/components/bandCombos/BandCombosList.js
+++ b/src/components/bandCombos/BandCombosList.js
@@ -17,6 +17,11 @@ class BandCombosList extends Component {
       return (
         <div className="BandCombosList">
           <div className="row">
+            { bandCombos.value.results.length === 0 &&
+              <div className="col-12">
+                <h3>Bird not found.</h3>
+              </div>
+            }
             { bandCombos.value.results.map((bandCombo) =>
               <div className="col-6 col-sm-4 col-md-3" key={ bandCombo.bird.slug }>
                 <BirdCard bird={ bandCombo.bird }  />
@@ -32,6 +37,6 @@ class BandCombosList extends Component {
 
 const mapStateToProps = (state) => {
   return { bandCombos: state.bandCombos };
-}
+};
 
 export default connect(mapStateToProps)(BandCombosList);

--- a/src/components/bandCombos/BandCombosList.js
+++ b/src/components/bandCombos/BandCombosList.js
@@ -19,7 +19,7 @@ class BandCombosList extends Component {
           <div className="row">
             { bandCombos.value.results.length === 0 &&
               <div className="col-12">
-                <h3>Bird not found.</h3>
+                <h3>No birds found with that search criteria.</h3>
               </div>
             }
             { bandCombos.value.results.map((bandCombo) =>


### PR DESCRIPTION
Fix #97 
It's been caused by `.constrainer overflow: hidden;`
Deleted it and moved `background-color: #fff` to root to cover the whole app area.
Added bird not found message.
