### PR TITLE
Fix #112 IE img size issue

### DIFF
--- a/src/components/birds/BirdsFeatured.scss
+++ b/src/components/birds/BirdsFeatured.scss
@@ -23,6 +23,7 @@
 
   img {
     max-height: 192px;
+    max-width: 192px;
     display: inline-block;
   }
 

--- a/src/components/helpers/ProfilePicture.scss
+++ b/src/components/helpers/ProfilePicture.scss
@@ -1,3 +1,11 @@
+.ProfilePicture {
+  min-height: 1px; // Workaround for IE img height issue https://github.com/philipwalton/flexbugs/issues/75
+
+  img {
+    width: 100%;
+  }
+}
+
 .ProfilePicture.isDead {
   position: relative;
 


### PR DESCRIPTION
Fix #112 
These were related to IE flexbox bugs: https://github.com/philipwalton/flexbugs/issues/75
Added width/height to workaround.
Looks good on both IE and Chrome.