### PR TITLE
Add guard condition for when bandCombo not defined

### DIFF
--- a/src/components/birds/BirdProfile.js
+++ b/src/components/birds/BirdProfile.js
@@ -60,7 +60,7 @@ class BirdProfile extends Component {
                   <ul className="list-unstyled mb-3">
                     <li><i className="fas fa-fw fa-info-circle"></i> { details.join(' ') }</li>
                     <li><i className="fas fa-fw fa-map-marker-alt"></i> { bird.study_area }</li>
-                    <li><i className="far fa-fw fa-circle"></i> { bird.band_combo }</li>
+                    <li><i className="far fa-fw fa-circle"></i> { bird.band_combo || 'Band combo not registered' }</li>
                   </ul>
                   <div className="band-combo">
                     <PrettyBandCombo bandCombo={ bird.band_combo } />

--- a/src/components/birds/BirdProfile.js
+++ b/src/components/birds/BirdProfile.js
@@ -60,7 +60,7 @@ class BirdProfile extends Component {
                   <ul className="list-unstyled mb-3">
                     <li><i className="fas fa-fw fa-info-circle"></i> { details.join(' ') }</li>
                     <li><i className="fas fa-fw fa-map-marker-alt"></i> { bird.study_area }</li>
-                    <li><i className="far fa-fw fa-circle"></i> { bird.band_combo || 'Band combo not registered' }</li>
+                    { bird.band_combo && <li><i className="far fa-fw fa-circle"></i> { bird.band_combo }</li> }
                   </ul>
                   <div className="band-combo">
                     <PrettyBandCombo bandCombo={ bird.band_combo } />

--- a/src/components/helpers/PrettyBandCombo.js
+++ b/src/components/helpers/PrettyBandCombo.js
@@ -4,6 +4,8 @@ import colours from '../helpers/colours';
 import './PrettyBandCombo.css';
 
 const PrettyBandCombo = ({ bandCombo }) => {
+  if (!bandCombo) return null;
+
   // [Common] Detect whether new band or not
   const isNew = bandCombo.includes('on');
 


### PR DESCRIPTION
https://api.keadatabase.nz/birds/loki/
`band_combo` is `null` and was causing error in PrettyBandCombo.js line 8:
```
  const isNew = bandCombo.includes('on');
```

Added guard condition in PrettyBandCombo and text explaination in BirdProfile.
